### PR TITLE
Use dataset filenames in t2i/t2v validation

### DIFF
--- a/src/cogkit/finetune/datasets/t2i_dataset.py
+++ b/src/cogkit/finetune/datasets/t2i_dataset.py
@@ -82,10 +82,19 @@ class BaseT2IDataset(Dataset):
         prompt_embedding = get_prompt_embedding(self.encode_text, prompt, cache_dir)
 
         if not self.using_train:
-            return {
+            result = {
                 "prompt": prompt,
                 "prompt_embedding": prompt_embedding,
             }
+            # Optional filename for nicer validation output
+            file_val = (
+                self.data[index].get("filename")
+                or self.data[index].get("file_name")
+                or self.data[index].get("path")
+            )
+            if file_val:
+                result["filename"] = Path(str(file_val)).stem
+            return result
 
         ##### image
         image = self.data[index]["image"]

--- a/src/cogkit/finetune/datasets/t2v_dataset.py
+++ b/src/cogkit/finetune/datasets/t2v_dataset.py
@@ -68,10 +68,18 @@ class BaseT2VDataset(Dataset):
         prompt_embedding = get_prompt_embedding(self.encode_text, prompt, cache_dir)
 
         if not self.using_train:
-            return {
+            result = {
                 "prompt": prompt,
                 "prompt_embedding": prompt_embedding,
             }
+            file_val = (
+                self.data[index].get("filename")
+                or self.data[index].get("file_name")
+                or self.data[index].get("path")
+            )
+            if file_val:
+                result["filename"] = Path(str(file_val)).stem
+            return result
 
         ##### video
         video = self.data[index]["video"]


### PR DESCRIPTION
## Summary
- pass dataset filenames to validation results for T2I and T2V datasets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cogkit' and torch)*

------
https://chatgpt.com/codex/tasks/task_e_685aba10fa4c832b9a3bacf0fe93496c