### PR TITLE
Use dataset filenames in t2i/t2v validation

### DIFF
--- a/src/cogkit/finetune/datasets/t2i_dataset.py
+++ b/src/cogkit/finetune/datasets/t2i_dataset.py
@@ -82,10 +82,19 @@ class BaseT2IDataset(Dataset):
         prompt_embedding = get_prompt_embedding(self.encode_text, prompt, cache_dir)
 
         if not self.using_train:
-            return {
+            result = {
                 "prompt": prompt,
                 "prompt_embedding": prompt_embedding,
             }
+            # Optional filename for nicer validation output
+            file_val = (
+                self.data[index].get("filename")
+                or self.data[index].get("file_name")
+                or self.data[index].get("path")
+            )
+            if file_val:
+                result["filename"] = Path(str(file_val)).stem
+            return result
 
         ##### image
         image = self.data[index]["image"]

--- a/src/cogkit/finetune/datasets/t2v_dataset.py
+++ b/src/cogkit/finetune/datasets/t2v_dataset.py
@@ -68,10 +68,18 @@ class BaseT2VDataset(Dataset):
         prompt_embedding = get_prompt_embedding(self.encode_text, prompt, cache_dir)
 
         if not self.using_train:
-            return {
+            result = {
                 "prompt": prompt,
                 "prompt_embedding": prompt_embedding,
             }
+            file_val = (
+                self.data[index].get("filename")
+                or self.data[index].get("file_name")
+                or self.data[index].get("path")
+            )
+            if file_val:
+                result["filename"] = Path(str(file_val)).stem
+            return result
 
         ##### video
         video = self.data[index]["video"]

--- a/src/cogkit/finetune/diffusion/models/cogvideo/cogvideox_i2v/lora_trainer.py
+++ b/src/cogkit/finetune/diffusion/models/cogvideo/cogvideox_i2v/lora_trainer.py
@@ -149,6 +149,7 @@ class CogVideoXI2VLoraTrainer(DiffusionTrainer):
             "image": [],
             "image_preprocessed": [],
             "encoded_videos": [],
+            "filename": [],
         }
 
         for sample in samples:
@@ -157,6 +158,7 @@ class CogVideoXI2VLoraTrainer(DiffusionTrainer):
             image = sample["image"]
             image_preprocessed = sample["image_preprocessed"]
             encoded_video = sample.get("encoded_video", None)
+            filename = sample.get("filename")
 
             ret["prompt"].append(prompt)
             ret["prompt_embedding"].append(prompt_embedding)
@@ -164,6 +166,8 @@ class CogVideoXI2VLoraTrainer(DiffusionTrainer):
             ret["image_preprocessed"].append(image_preprocessed)
             if encoded_video is not None:
                 ret["encoded_videos"].append(encoded_video)
+            if filename is not None:
+                ret["filename"].append(filename)
 
         ret["prompt_embedding"] = torch.stack(ret["prompt_embedding"])
         ret["image_preprocessed"] = torch.stack(ret["image_preprocessed"])

--- a/src/cogkit/finetune/diffusion/models/cogvideo/cogvideox_t2v/lora_trainer.py
+++ b/src/cogkit/finetune/diffusion/models/cogvideo/cogvideox_t2v/lora_trainer.py
@@ -139,17 +139,25 @@ class CogVideoXT2VLoraTrainer(DiffusionTrainer):
 
     @override
     def collate_fn(self, samples: list[dict[str, Any]]) -> dict[str, Any]:
-        ret = {"prompt": [], "prompt_embedding": [], "encoded_videos": []}
+        ret = {
+            "prompt": [],
+            "prompt_embedding": [],
+            "encoded_videos": [],
+            "filename": [],
+        }
 
         for sample in samples:
             prompt = sample.get("prompt", None)
             prompt_embedding = sample.get("prompt_embedding", None)
             encoded_video = sample.get("encoded_video", None)
+            filename = sample.get("filename")
 
             ret["prompt"].append(prompt)
             ret["prompt_embedding"].append(prompt_embedding)
             if encoded_video is not None:
                 ret["encoded_videos"].append(encoded_video)
+            if filename is not None:
+                ret["filename"].append(filename)
 
         ret["prompt_embedding"] = torch.stack(ret["prompt_embedding"])
         ret["encoded_videos"] = (

--- a/src/cogkit/finetune/diffusion/models/cogview/cogview4/lora_trainer.py
+++ b/src/cogkit/finetune/diffusion/models/cogview/cogview4/lora_trainer.py
@@ -186,6 +186,7 @@ class Cogview4Trainer(DiffusionTrainer):
             "image": [],
             "encoded_image": [],
             "text_attn_mask": None,
+            "filename": [],
         }
 
         for sample in samples:
@@ -193,6 +194,7 @@ class Cogview4Trainer(DiffusionTrainer):
             prompt_embedding = sample.get("prompt_embedding", None)
             image = sample.get("image", None)
             encoded_image = sample.get("encoded_image", None)
+            filename = sample.get("filename")
 
             ret["prompt"].append(prompt)
             ret["prompt_embedding"].append(prompt_embedding)
@@ -201,6 +203,8 @@ class Cogview4Trainer(DiffusionTrainer):
                 ret["image"].append(image)
             if encoded_image is not None:
                 ret["encoded_image"].append(encoded_image)
+            if filename is not None:
+                ret["filename"].append(filename)
 
         prompt_embedding, prompt_attention_mask = process_prompt_attention_mask(
             self.components.tokenizer,


### PR DESCRIPTION
## Summary
- pass dataset filenames to validation results for T2I and T2V datasets
- keep filenames when collating I2V/T2V/T2I batches

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cogkit' and torch)*

------
https://chatgpt.com/codex/tasks/task_e_685aba10fa4c832b9a3bacf0fe93496c