### PR TITLE
Customize output dir and epoch artifacts

### DIFF
--- a/src/cogkit/finetune/base/base_args.py
+++ b/src/cogkit/finetune/base/base_args.py
@@ -167,4 +167,16 @@ class BaseArgs(BaseModel):
         with open(fpath, "r") as f:
             yaml_dict = yaml.safe_load(f)
 
+        # ------------------------------------------------------------------
+        # Dynamically set the ``output_dir`` based on learning rate and
+        # batch size.  The folder will be created directly under the
+        # repository root with the name:
+        #   ``Output1__LR_<learning_rate>__BS_<batch_size>``
+        # ------------------------------------------------------------------
+        lr = yaml_dict.get("learning_rate")
+        bs = yaml_dict.get("batch_size")
+        if lr is not None and bs is not None:
+            repo_root = Path(__file__).resolve().parents[4]
+            yaml_dict["output_dir"] = repo_root / f"Output1__LR_{lr}__BS_{bs}"
+
         return cls(**yaml_dict)

--- a/src/cogkit/finetune/base/base_trainer.py
+++ b/src/cogkit/finetune/base/base_trainer.py
@@ -351,6 +351,21 @@ class BaseTrainer(ABC):
                 f"Memory after epoch {epoch + 1}: {json.dumps(memory_statistics, indent=4)}"
             )
 
+            # --------------------------------------------------------------
+            # At the end of every epoch save a checkpoint and run validation
+            # --------------------------------------------------------------
+            ckpt_path = self.maybe_save_checkpoint(global_step, must_save=True)
+            if ckpt_path is not None:
+                epoch_ckpt = self.uargs.output_dir / f"Checkpoint_Epoch_{epoch + 1}"
+                if is_main_process():
+                    Path(ckpt_path).rename(epoch_ckpt)
+            else:
+                epoch_ckpt = None
+
+            if self.uargs.do_validation:
+                free_memory()
+                self.validate(epoch + 1, ckpt_path=epoch_ckpt)
+
     def train_step(self, batch: dict[str, Any], sync_grad: bool) -> dict[str, Any]:
         logs = {}
 

--- a/src/cogkit/finetune/diffusion/trainer.py
+++ b/src/cogkit/finetune/diffusion/trainer.py
@@ -263,7 +263,7 @@ class DiffusionTrainer(BaseTrainer):
             )
 
             artifacts: dict[str, Any] = {}
-            val_path = self.uargs.output_dir / "validation_res" / f"validation-{step}"
+            val_path = self.uargs.output_dir / f"validation_Epoch_{step}"
             mkdir(val_path)
 
             # ------------------------- BASENAME -------------------------


### PR DESCRIPTION
## Summary
- set output_dir dynamically in `BaseArgs.parse_from_yaml`
- save a checkpoint and run validation at the end of each epoch
- save validation results per epoch in folders named `validation_Epoch_<n>`

## Testing
- `pre-commit run --files src/cogkit/finetune/base/base_args.py src/cogkit/finetune/base/base_trainer.py src/cogkit/finetune/diffusion/trainer.py` *(fails: error 403 from github.com)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685e8b7bb0d0832ba806bbbc82eccbe2