### PR TITLE
Customize output dir and epoch artifacts

### DIFF
--- a/src/cogkit/finetune/base/base_trainer.py
+++ b/src/cogkit/finetune/base/base_trainer.py
@@ -351,6 +351,16 @@ class BaseTrainer(ABC):
                 f"Memory after epoch {epoch + 1}: {json.dumps(memory_statistics, indent=4)}"
             )
 
+
+            # --------------------------------------------------------------
+            # Hook for subclasses: run logic at the end of each epoch
+            # --------------------------------------------------------------
+            self.on_epoch_end(epoch, global_step)
+
+    def on_epoch_end(self, epoch: int, global_step: int) -> None:
+        """Hook called at the end of each training epoch."""
+        return None
+
     def train_step(self, batch: dict[str, Any], sync_grad: bool) -> dict[str, Any]:
         logs = {}
 

--- a/src/cogkit/finetune/diffusion/trainer.py
+++ b/src/cogkit/finetune/diffusion/trainer.py
@@ -21,6 +21,7 @@ from ..utils import (
     free_memory,
     get_memory_statistics,
     gather_object,
+    is_main_process,
     mkdir,
 )
 from .schemas import DiffusionArgs, DiffusionComponents, DiffusionState
@@ -263,7 +264,7 @@ class DiffusionTrainer(BaseTrainer):
             )
 
             artifacts: dict[str, Any] = {}
-            val_path = self.uargs.output_dir / "validation_res" / f"validation-{step}"
+            val_path = self.uargs.output_dir / f"validation_Epoch_{step}"
             mkdir(val_path)
 
             # ------------------------- BASENAME -------------------------
@@ -344,6 +345,23 @@ class DiffusionTrainer(BaseTrainer):
         torch.cuda.reset_peak_memory_stats(self.state.device)
         torch.set_grad_enabled(True)
         self.components.transformer.train()
+
+    # ------------------------------------------------------------------
+    #                           EPOCH HOOK
+    # ------------------------------------------------------------------
+    @override
+    def on_epoch_end(self, epoch: int, global_step: int) -> None:
+        ckpt_path = self.maybe_save_checkpoint(global_step, must_save=True)
+        if ckpt_path is not None:
+            epoch_ckpt = self.uargs.output_dir / f"Checkpoint_Epoch_{epoch + 1}"
+            if is_main_process():
+                Path(ckpt_path).rename(epoch_ckpt)
+        else:
+            epoch_ckpt = None
+
+        if self.uargs.do_validation:
+            free_memory()
+            self.validate(epoch + 1, ckpt_path=epoch_ckpt)
 
     # ------------------------------------------------------------------
     #                       ABSTRACT / OVERRIDE METHODS


### PR DESCRIPTION
## Summary
- compute `output_dir` relative to the `CogKitFix` repo location
- validate optional `validation_steps`
- provide an `on_epoch_end` hook in `BaseTrainer`
- in `DiffusionTrainer`, save checkpoint and run validation at each epoch end

## Testing
- `pre-commit run --files src/cogkit/finetune/base/base_args.py src/cogkit/finetune/base/base_trainer.py src/cogkit/finetune/diffusion/trainer.py` *(fails: HTTP 403 from github.com)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cogkit' & 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685e8b7bb0d0832ba806bbbc82eccbe2