### PR TITLE
Simplify training workflow

### DIFF
--- a/src/cogkit/finetune/base/base_trainer.py
+++ b/src/cogkit/finetune/base/base_trainer.py
@@ -339,6 +339,11 @@ class BaseTrainer(ABC):
 
                     progress_bar.set_postfix(logs)
 
+                    if "loss" in logs:
+                        self.logger.info(
+                            "Step %d: loss=%.6f", global_step, logs["loss"]
+                        )
+
                     if self.tracker is not None:
                         self.tracker.log(logs, step=global_step)
 

--- a/src/cogkit/finetune/diffusion/trainer.py
+++ b/src/cogkit/finetune/diffusion/trainer.py
@@ -359,7 +359,7 @@ class DiffusionTrainer(BaseTrainer):
         else:
             epoch_ckpt = None
 
-        if self.uargs.do_validation:
+        if self.uargs.do_validation and (epoch + 1) == self.uargs.train_epochs:
             free_memory()
             self.validate(epoch + 1, ckpt_path=epoch_ckpt)
 


### PR DESCRIPTION
## Summary
- train only once in `iterative_training.py`
- parse hyperparameters from CLI
- validate only at final epoch
- log training loss each step
- compute only MSE in metrics script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `cogkit` and `torch`)*

------
https://chatgpt.com/codex/tasks/task_e_68627204e810832bbaab4094749de854